### PR TITLE
Option to show all files on project load

### DIFF
--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -717,11 +717,27 @@ namespace FrostyEditor.Windows
                 // Update UI
                 UpdateUI();
 
+                bool allFiles = Config.Get("ShowAllFiles", false);
+
                 legacyExplorer.ShowOnlyModified = false;
-                legacyExplorer.ShowOnlyModified = true;
+                if(allFiles)
+                {
+                    legacyExplorer.ShowOnlyModified = false;
+                }
+                else
+                {
+                    legacyExplorer.ShowOnlyModified = true;
+                }
 
                 dataExplorer.ShowOnlyModified = false;
-                dataExplorer.ShowOnlyModified = true;
+                if (allFiles)
+                {
+                    dataExplorer.ShowOnlyModified = false;
+                }
+                else
+                {
+                    dataExplorer.ShowOnlyModified = true;
+                }
 
                 legacyExplorer.ShowOnlyUnModified = false;
                 legacyExplorer.ShowOnlyUnModified = false;

--- a/FrostyPlugin/Windows/OptionsWindow.xaml.cs
+++ b/FrostyPlugin/Windows/OptionsWindow.xaml.cs
@@ -180,6 +180,12 @@ namespace Frosty.Core.Windows
         public bool RememberChoice { get; set; } = false;
 
         [Category("Editor")]
+        [DisplayName("Show All Files on Project Load")]
+        [Description("If true, the show modified files option will not be checked when loading a project.")]
+        [EbxFieldMeta(EbxFieldType.Boolean)]
+        public bool ShowAllFiles { get; set; } = false;
+
+        [Category("Editor")]
         [DisplayName("Set as Default Installation")]
         [Description("Use this installation for .fbproject files.")]
         [EbxFieldMeta(EbxFieldType.Boolean)]
@@ -212,6 +218,7 @@ namespace Frosty.Core.Windows
 
             AssetDisplayModuleInId = Config.Get<bool>("DisplayModuleInId", false);
             RememberChoice = Config.Get<bool>("UseDefaultProfile", false);
+            ShowAllFiles = Config.Get<bool>("ShowAllFiles", false);
 
             //Checks the registry for the current association instead of loading from config
             string KeyName = "frostyproject";
@@ -238,6 +245,7 @@ namespace Frosty.Core.Windows
             Config.Add("ModAuthor", ModSettingsAuthor);
             Config.Add("DisplayModuleInId", AssetDisplayModuleInId);
             Config.Add("UseDefaultProfile", RememberChoice);
+            Config.Add("ShowAllFiles", ShowAllFiles);
 
             if (RememberChoice)
                 Config.Add("DefaultProfile", ProfilesLibrary.ProfileName);


### PR DESCRIPTION
Previously, the editor would always check "Show Modified Files" when loading a project file. This new option will prevent this from happening when it is checked.

![image](https://github.com/bphit4/Frosty-M24/assets/10275497/c2084b7f-62fd-41ab-aaa0-06a6ee6d15cf)
