### PR TITLE
Added toolbar option to delete ModData and launch

### DIFF
--- a/FrostyEditor/Windows/MainWindow.xaml
+++ b/FrostyEditor/Windows/MainWindow.xaml
@@ -119,7 +119,9 @@
                     <MenuItem x:Name="AboutMenuItem" Header="About Frosty Editor" Click="aboutMenuItem_Click"/>
                 </MenuItem>
             </Menu>
+            <MenuItem x:Name="LaunchDataDelete" Header="Delete ModData and Launch" Height="22" Visibility="Collapsed" Click="LaunchDataDelete_Click" Foreground="White" Margin="331,0,0,0" Width="174" VerticalAlignment="Center" HorizontalAlignment="Left" Padding="-26,0,-49,0"/>
             <MenuItem x:Name="RestoreMadden" Header="Restore Madden 24" Height="22" Visibility="Collapsed" Click="RestoreMadden_Click" Foreground="White" Margin="331,0,0,0" Width="125" VerticalAlignment="Center" HorizontalAlignment="Left" Padding="-26,0,-49,0"/>
+
         </Grid>
 
         <Grid Grid.Row="1" Background="{StaticResource ListBackground}">

--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -316,9 +316,20 @@ namespace FrostyEditor.Windows
                 InitFifaMenu();
             }
 
+            // Only show option to delete ModData and launch if a profile is loaded
+            if (ProfilesLibrary.HasLoadedProfile)
+            {
+                LaunchDataDelete.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                LaunchDataDelete.Visibility = Visibility.Collapsed;
+            }
+
             if (ProfilesLibrary.IsLoaded(ProfileVersion.Madden24))
             {
                 RestoreMadden.Visibility = Visibility.Visible;
+                RestoreMadden.Margin = new Thickness(LaunchDataDelete.Margin.Left + LaunchDataDelete.Width, 0, 0, 0);
             }
             else
             {
@@ -1098,7 +1109,41 @@ namespace FrostyEditor.Windows
             AboutWindow win = new AboutWindow();
             win.ShowDialog();
         }
+        private void LaunchDataDelete_Click(object sender, RoutedEventArgs e)
+        {
+            string modDataPath = Config.Get<string>("GamePath", "", ConfigScope.Game, ProfilesLibrary.ProfileName) + "\\ModData";
 
+            if (!Directory.Exists(modDataPath))
+            {
+                // ModData folder doesn't exist, proceed with the default launch
+                launchButton_Click(sender, e);
+                return;
+            }
+
+            try
+            {
+                // Attempt to delete the ModData folder
+                Directory.Delete(modDataPath, true);
+
+                // ModData deleted successfully, proceed with the default launch
+                launchButton_Click(sender, e);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Handle UnauthorizedAccessException (e.g., folder access denied)
+                FrostyMessageBox.Show("Error deleting ModData!\nAccess to ModData folder denied. Try running Frosty as Administrator.", "Frosty Editor", MessageBoxButton.OK);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Handle DirectoryNotFoundException (e.g., folder not found)
+                FrostyMessageBox.Show("Error deleting ModData!\nModData folder not found.", "Frosty Editor", MessageBoxButton.OK);
+            }
+            catch (Exception ex)
+            {
+                // Handle other exceptions
+                FrostyMessageBox.Show($"An unexpected error occurred: {ex.Message}", "Frosty Editor", MessageBoxButton.OK);
+            }
+        }
         private void RestoreMadden_Click(object sender, RoutedEventArgs e)
         {
             string pathFile = "selectedFolder.txt";

--- a/FrostyModManager/Windows/MainWindow.xaml
+++ b/FrostyModManager/Windows/MainWindow.xaml
@@ -168,7 +168,8 @@
                     <MenuItem x:Name="aboutMenuItem" Header="About Frosty Mod Manager" Click="aboutMenuItem_Click"/>
                 </MenuItem>
             </Menu>
-            <MenuItem x:Name="RestoreMadden" Header="Restore Madden 24" Height="22" Click="RestoreMadden_Click" Foreground="White" Margin="146,0,0,0" Width="125" VerticalAlignment="Center" HorizontalAlignment="Left" Padding="-26,0,-49,0"/>
+            <MenuItem x:Name="LaunchDataDelete" Header="Delete ModData and Launch" Height="22" Click="LaunchDataDelete_Click" Foreground="White" Margin="146,0,0,0" Width="174" VerticalAlignment="Center" HorizontalAlignment="Left" Padding="-26,0,-49,0"/>
+            <MenuItem x:Name="RestoreMadden" Header="Restore Madden 24" Height="22" Click="RestoreMadden_Click" Foreground="White" Margin="320,0,0,0" Width="125" VerticalAlignment="Center" HorizontalAlignment="Left" Padding="-26,0,-49,0"/>
             <!-- Toolbar -->
             <Grid Grid.Row="1" Background="{StaticResource ListBackground}">
                 <Grid.ColumnDefinitions>

--- a/FrostyModManager/Windows/MainWindow.xaml.cs
+++ b/FrostyModManager/Windows/MainWindow.xaml.cs
@@ -1916,6 +1916,42 @@ namespace FrostyModManager
         {
             ((ListView)sender).UnselectAll();
         }
+
+        private void LaunchDataDelete_Click(object sender, RoutedEventArgs e)
+        {
+            string modDataPath = Config.Get<string>("GamePath", "", ConfigScope.Game, ProfilesLibrary.ProfileName) + "\\ModData";
+
+            if (!Directory.Exists(modDataPath))
+            {
+                // ModData folder doesn't exist, proceed with the default launch
+                launchButton_Click(sender, e);
+                return;
+            }
+
+            try
+            {
+                // Attempt to delete the ModData folder
+                Directory.Delete(modDataPath, true);
+
+                // ModData deleted successfully, proceed with the default launch
+                launchButton_Click(sender, e);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Handle UnauthorizedAccessException (e.g., folder access denied)
+                FrostyMessageBox.Show("Error deleting ModData!\nAccess to ModData folder denied. Try running Frosty as Administrator.", "Frosty Mod Manager", MessageBoxButton.OK);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Handle DirectoryNotFoundException (e.g., folder not found)
+                FrostyMessageBox.Show("Error deleting ModData!\nModData folder not found.", "Frosty Mod Manager", MessageBoxButton.OK);
+            }
+            catch (Exception ex)
+            {
+                // Handle other exceptions
+                FrostyMessageBox.Show($"An unexpected error occurred: {ex.Message}", "Frosty Mod Manager", MessageBoxButton.OK);
+            }
+        }
         private void RestoreMadden_Click(object sender, RoutedEventArgs e)
         {
             string pathFile = "selectedFolder.txt";


### PR DESCRIPTION
While previously doable through the Manage ModData menu, this is a one-click option in the toolbar to delete ModData and launch. The Restore Madden 24 button has been shifted right to accommodate the new button.

![image](https://github.com/bphit4/Frosty-M24/assets/10275497/22db4eac-0ba0-4f09-b0ec-67157a8c1f4d)

![image](https://github.com/bphit4/Frosty-M24/assets/10275497/0fa8362b-7b99-4c6c-88f3-bbcd8b5c2bba)
