### PR TITLE
Initial mesh support for Madden 24

### DIFF
--- a/FrostyPlugin/Viewport/RenderMesh.cs
+++ b/FrostyPlugin/Viewport/RenderMesh.cs
@@ -1087,7 +1087,7 @@ namespace Frosty.Core.Viewport
             }
             if (NormTexture == null)
             {
-                NormTexture = state.TextureLibrary.LoadTextureAsset(App.AssetManager.GetEbxEntry(ProfilesLibrary.DefaultNormals).Guid);
+                //NormTexture = state.TextureLibrary.LoadTextureAsset(App.AssetManager.GetEbxEntry(ProfilesLibrary.DefaultNormals).Guid);
             }
             if (MaskTexture == null)
             {

--- a/Plugins/MeshSetPlugin/Resources/MeshSet.cs
+++ b/Plugins/MeshSetPlugin/Resources/MeshSet.cs
@@ -776,8 +776,7 @@ namespace MeshSetPlugin.Resources
                     m_unknownHash3 = reader.ReadUInt(); // some other hash
                 }
 
-                //reader.Pad(16);
-                reader.Pad(32);
+                reader.Pad(16);
                 reader.Pad(32);
                 if (ProfilesLibrary.IsLoaded(ProfileVersion.DeadSpace))
                 {

--- a/Plugins/MeshSetPlugin/Resources/MeshSet.cs
+++ b/Plugins/MeshSetPlugin/Resources/MeshSet.cs
@@ -776,7 +776,8 @@ namespace MeshSetPlugin.Resources
                     m_unknownHash3 = reader.ReadUInt(); // some other hash
                 }
 
-                reader.Pad(16);
+                //reader.Pad(16);
+                reader.Pad(32);
                 reader.Pad(32);
                 if (ProfilesLibrary.IsLoaded(ProfileVersion.DeadSpace))
                 {

--- a/Plugins/MeshSetPlugin/Resources/MeshSet.cs
+++ b/Plugins/MeshSetPlugin/Resources/MeshSet.cs
@@ -927,6 +927,11 @@ namespace MeshSetPlugin.Resources
 
                 writer.Write(m_unk2);
 
+                if (ProfilesLibrary.IsLoaded(ProfileVersion.Madden24))
+                {
+                    writer.Write(m_unknownm24);
+                }
+
                 if (ProfilesLibrary.IsLoaded(ProfileVersion.Battlefield2042, ProfileVersion.NeedForSpeedUnbound))
                 {
                     writer.Write(0L);
@@ -1102,6 +1107,7 @@ namespace MeshSetPlugin.Resources
                 }
 
                 writer.WritePadding(16);
+                writer.WritePadding(32);
                 writer.Write(m_boundingBox);
             }
             else
@@ -1732,6 +1738,11 @@ namespace MeshSetPlugin.Resources
                 writer.Write(0L);
             }
 
+            if (ProfilesLibrary.IsLoaded(ProfileVersion.Madden24))
+            {
+                writer.Write(m_unknownm24);
+            }
+
             writer.Write(m_chunkId);
             writer.Write(m_inlineDataOffset);
 
@@ -2348,6 +2359,11 @@ namespace MeshSetPlugin.Resources
                 {
                     writer.Write(m_unknownUInts[i]);
                 }
+            }
+            else if (ProfilesLibrary.IsLoaded(ProfileVersion.Madden24))
+            {
+                writer.Write((byte)m_meshType);
+                writer.Write(m_unknownm24);
             }
             else
             {

--- a/Plugins/MeshSetPlugin/Resources/MeshSet.cs
+++ b/Plugins/MeshSetPlugin/Resources/MeshSet.cs
@@ -522,6 +522,7 @@ namespace MeshSetPlugin.Resources
         private byte m_bonesPerVertex;
         private ushort m_unk1;
         private uint m_unk2;
+        private byte[] m_unknownm24;
 
         private bool m_hasUnknown;
         private bool m_hasUnknown2;
@@ -578,6 +579,11 @@ namespace MeshSetPlugin.Resources
                 m_vertexCount = reader.ReadUInt();
 
                 m_unk2 = reader.ReadUInt();
+
+                if (ProfilesLibrary.IsLoaded(ProfileVersion.Madden24))
+                {
+                    m_unknownm24 = reader.ReadBytes(16);
+                }
 
                 if (ProfilesLibrary.IsLoaded(ProfileVersion.Battlefield2042, ProfileVersion.NeedForSpeedUnbound, ProfileVersion.DeadSpace))
                 {
@@ -771,6 +777,7 @@ namespace MeshSetPlugin.Resources
                 }
 
                 reader.Pad(16);
+                reader.Pad(32);
                 if (ProfilesLibrary.IsLoaded(ProfileVersion.DeadSpace))
                 {
                     reader.ReadBytes(16);
@@ -1252,7 +1259,7 @@ namespace MeshSetPlugin.Resources
         private uint m_inlineDataOffset;
         private byte[] m_adjacencyData;
         private bool m_hasBoneShortNames;
-
+        private byte[] m_unknownm24;
         public MeshSetLod(NativeReader reader, AssetManager am, ref int sectionIndex)
         {
             m_meshType = (MeshType)reader.ReadUInt();
@@ -1325,6 +1332,11 @@ namespace MeshSetPlugin.Resources
                 {
                     reader.ReadUInt();
                 }
+            }
+
+            if (ProfilesLibrary.IsLoaded(ProfileVersion.Madden24))
+            {
+                m_unknownm24 = reader.ReadBytes(12);
             }
 
             m_chunkId = reader.ReadGuid();
@@ -1874,6 +1886,7 @@ namespace MeshSetPlugin.Resources
         private string m_name;
         private uint m_nameHash;
         private MeshType m_meshType;
+        private byte[] m_unknownm24; 
         private byte m_unk;
         private MeshSetLayoutFlags m_flags;
         private ushort[] m_lodFadeDistanceFactors = new ushort[MaxLodCount * 2];
@@ -1935,6 +1948,11 @@ namespace MeshSetPlugin.Resources
                 {
                     m_unknownUInts[i] = reader.ReadUInt();
                 }
+            }
+            else if (ProfilesLibrary.IsLoaded(ProfileVersion.Madden24))
+            {
+                m_meshType = (MeshType)reader.ReadByte();
+                m_unknownm24 = reader.ReadBytes(19);
             }
             else
             {


### PR DESCRIPTION
SkinnedMeshAssets, CompositeMeshAssets, and some RigidMeshAssets for Madden 24 can now be viewed and exported.