### PR TITLE
Simplified exception box and better exception messages

### DIFF
--- a/FrostyEditor/App.xaml.cs
+++ b/FrostyEditor/App.xaml.cs
@@ -103,7 +103,7 @@ namespace FrostyEditor
             using (NativeWriter writer = new NativeWriter(new FileStream("crashlog.txt", FileMode.Create)))
                 writer.WriteLine($"{exp.Message}\r\n\r\n{exp.StackTrace}");
 
-            FrostyExceptionBox.Show(exp, "Frosty Editor");
+            FrostyMessageBox.Show(exp.Message, "Frosty Editor");
             Environment.Exit(0);
         }
 

--- a/FrostyModManager/App.xaml.cs
+++ b/FrostyModManager/App.xaml.cs
@@ -94,7 +94,12 @@ namespace FrostyModManager
             using (NativeWriter writer = new NativeWriter(new FileStream("crashlog.txt", FileMode.Create)))
                 writer.WriteLine($"{exp.Message}\r\n\r\n{exp.StackTrace}");
 
+            #if FROSTY_DEVELOPER
             FrostyExceptionBox.Show(exp, "Frosty Mod Manager");
+            #else
+            FrostyMessageBox.Show(exp.Message, "Frosty Mod Manager");
+            #endif
+
             Environment.Exit(0);
         }
 

--- a/FrostyModManager/App.xaml.cs
+++ b/FrostyModManager/App.xaml.cs
@@ -90,6 +90,20 @@ namespace FrostyModManager
         private void App_DispatcherUnhandledException(object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
         {
             Exception exp = e.Exception;
+            string message;
+
+            if(exp is AggregateException)
+            {
+                message = "One or more errors occurred. Please ensure all applied mods are up to date or compatible with the latest game version.";
+            }
+            else if (exp is UnauthorizedAccessException)
+            {
+                message = "Access to a file or directory is denied. Please ensure to run the Mod Manager as Administrator.";
+            }
+            else
+            {
+                message = exp.Message;
+            }
 
             using (NativeWriter writer = new NativeWriter(new FileStream("crashlog.txt", FileMode.Create)))
                 writer.WriteLine($"{exp.Message}\r\n\r\n{exp.StackTrace}");
@@ -97,7 +111,7 @@ namespace FrostyModManager
             #if FROSTY_DEVELOPER
             FrostyExceptionBox.Show(exp, "Frosty Mod Manager");
             #else
-            FrostyMessageBox.Show(exp.Message, "Frosty Mod Manager");
+            FrostyMessageBox.Show(message, "Frosty Mod Manager");
             #endif
 
             Environment.Exit(0);


### PR DESCRIPTION
Editor:
- Replaced exception box with message box that shows only the error message without stack trace

Mod Manager:
- For non-developer builds, replaced exception box with message box that shows only the error message without stack trace. Developer builds will still show the old exception box with stack trace.
- Made the exception messages for out of date mods and access denied errors more helpful