### PR TITLE
Initial Legacy Lag Fix

### DIFF
--- a/FrostyPlugin/Legacy/LegacyFileManagerV2.cs
+++ b/FrostyPlugin/Legacy/LegacyFileManagerV2.cs
@@ -220,10 +220,12 @@ namespace Frosty.Core.Legacy
                 writer.Write(data);
 
             App.AssetManager.RevertAsset(lfe);
-
+            Guid originalChunkId = lfe.ChunkId;
             ChunkAssetEntry orig = App.AssetManager.GetChunkEntry(lfe.ChunkId);
 
-            Guid guid = App.AssetManager.AddChunk(data, GenerateDeterministicGuid(lfe));
+            App.AssetManager.ModifyChunk(originalChunkId, data);
+
+            Guid guid = originalChunkId; 
             foreach (LegacyFileEntry.ChunkCollectorInstance inst in lfe.CollectorInstances)
             {
                 // add new chunk


### PR DESCRIPTION
This fixes lag issues when editing large legacy files such as the player portraits AST.

This is accomplished by modifying the LegacyAssetManager to update the original chunks of legacy files rather than creating new chunks, allowing preloading to work properly.

Needs to be tested to ensure it works on all legacy files but works for key ASTs, including portraits.