### PR TITLE
Blocked M24 Mod Manager SDK update by default

### DIFF
--- a/FrostyPlugin/Windows/FrostyProfileTaskWindow.xaml.cs
+++ b/FrostyPlugin/Windows/FrostyProfileTaskWindow.xaml.cs
@@ -122,6 +122,21 @@ namespace Frosty.Core.Windows
             // check to make sure SDK is up to date
             if (TypeLibrary.GetSdkVersion() != App.FileSystemManager.Head)
             {
+                // If Mod Manager and Madden 24, then if the config option agrees, show a message informing the user that they need to download the latest tool from MMC and link there.
+                if (!App.IsEditor)
+                {
+                    if (ProfilesLibrary.IsLoaded(ProfileVersion.Madden24) && !Config.Get<bool>("AllowM24SdkUpdate", false))
+                    {
+                        MessageBoxResult discResult = FrostyMessageBox.Show("The Madden NFL 24 SDK is out of date. Please ensure that your game is up to date and that you are using the latest version of the Mod Manager from the MMC Discord.\n\nWould you like to go to the MMC Discord now?", "Frosty Mod Manager", MessageBoxButton.YesNo);
+
+                        if (discResult == MessageBoxResult.Yes)
+                        {
+                            System.Diagnostics.Process.Start("https://discord.gg/maddenmoddingcommunity");
+                        }
+                        Environment.Exit(0);
+                    }
+                }
+                
                 // requires updating
                 if (UpdateSdk())
                 {

--- a/FrostyPlugin/Windows/OptionsWindow.xaml.cs
+++ b/FrostyPlugin/Windows/OptionsWindow.xaml.cs
@@ -342,6 +342,12 @@ namespace Frosty.Core.Windows
         public bool RememberChoice { get; set; } = false;
 
         [Category("Manager")]
+        [DisplayName("Allow Manual M24 SDK Update")]
+        [Description("If true, the option to update the Madden 24 SDK when out of date will be available.")]
+        [EbxFieldMeta(EbxFieldType.Boolean)]
+        public bool AllowM24SDKUpdate { get; set; } = false;
+
+        [Category("Manager")]
         [DisplayName("Command Line Arguments")]
         [Description("Command line arguments to run on launch.")]
         [EbxFieldMeta(EbxFieldType.Boolean)]
@@ -352,6 +358,7 @@ namespace Frosty.Core.Windows
             base.Load();
             
             RememberChoice = Config.Get<bool>("UseDefaultProfile", false);
+            AllowM24SDKUpdate = Config.Get<bool>("AllowM24SdkUpdate", false);
             CommandLineArgs = Config.Get<string>("CommandLineArgs", "", ConfigScope.Game);
         }
 
@@ -360,6 +367,7 @@ namespace Frosty.Core.Windows
             base.Save();
             
             Config.Add("UseDefaultProfile", RememberChoice);
+            Config.Add("AllowM24SdkUpdate", AllowM24SDKUpdate);
             Config.Add("CommandLineArgs", CommandLineArgs, ConfigScope.Game);
 
             if (RememberChoice)


### PR DESCRIPTION
Mod Manager will now block M24 SDK update unless config option is enabled to allow it. If blocked, the message will direct users to MMC Discord to download latest tool.

![image](https://github.com/bphit4/Frosty-M24/assets/10275497/2d79ad6e-9fae-4468-a276-4d911a7cf822)

![image](https://github.com/bphit4/Frosty-M24/assets/10275497/d0669f73-d318-4480-ac49-71838bf31291)
