### PR TITLE
Added Copy Chunk ID to legacy explorer context menu

### DIFF
--- a/FrostyEditor/Windows/MainWindow.xaml
+++ b/FrostyEditor/Windows/MainWindow.xaml
@@ -747,6 +747,11 @@
                                                     <Image Source="/FrostyEditor;component/Images/Copy.png"/>
                                                 </MenuItem.Icon>
                                             </MenuItem>
+                                            <MenuItem Header="Copy Chunk ID" Click="contextMenuCopyChunk_Click">
+                                                <MenuItem.Icon>
+                                                    <Image Source="/FrostyEditor;component/Images/Copy.png"/>
+                                                </MenuItem.Icon>
+                                            </MenuItem>
                                         </ContextMenu>
                                     </core:FrostyDataExplorer.AssetContextMenu>
                                 </core:FrostyDataExplorer>

--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -2015,5 +2015,23 @@ namespace FrostyEditor.Windows
                 Clipboard.SetText(paths.ToString().TrimEnd());
             }
         }
+
+        // Copy legacy asset's chunk ID to clipboard
+        private void contextMenuCopyChunk_Click(object sender, RoutedEventArgs e)
+        {
+            var selectedAssets = m_currentExplorer.SelectedAssets;
+            if (selectedAssets != null && selectedAssets.Count > 0)
+            {
+                StringBuilder chunkIds = new StringBuilder();
+                foreach (var asset in selectedAssets)
+                {
+                    if (asset is LegacyFileEntry legacyAsset)
+                    {
+                        chunkIds.AppendLine(legacyAsset.ChunkId.ToString());
+                    }
+                }
+                Clipboard.SetText(chunkIds.ToString().TrimEnd());
+            }
+        }
     }
 }


### PR DESCRIPTION
Legacy Explorer assets will now have an option to copy the associated chunk ID in the context menu.
![image](https://github.com/bphit4/Frosty-M24/assets/10275497/93b9862f-9679-4161-8045-6a7ebf7d9b2d)
