### PR TITLE
Fixed issue with reselect profile in editor not clearing

### DIFF
--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -552,13 +552,6 @@ namespace FrostyEditor.Windows
             // Create a new instance of the program and exit the current instance
             System.Diagnostics.Process.Start(Application.ResourceAssembly.Location);
             Close();
-
-            string selectedProfileName = FrostyProfileSelectWindow.Show();
-            if (!string.IsNullOrEmpty(selectedProfileName) && SelectProfile(selectedProfileName))
-            {
-                NewProject();
-                UpdateUI(true);
-            }
         }
 
         private static bool SelectProfile(string profile)

--- a/FrostyEditor/Windows/MainWindow.xaml.cs
+++ b/FrostyEditor/Windows/MainWindow.xaml.cs
@@ -546,6 +546,13 @@ namespace FrostyEditor.Windows
         private void reselectProfileMenuItem_Click(object sender, RoutedEventArgs e)
         {
             PromptToSaveDirtyProject();
+            Config.Remove("DefaultProfile");
+            Config.Save();
+
+            // Create a new instance of the program and exit the current instance
+            System.Diagnostics.Process.Start(Application.ResourceAssembly.Location);
+            Close();
+
             string selectedProfileName = FrostyProfileSelectWindow.Show();
             if (!string.IsNullOrEmpty(selectedProfileName) && SelectProfile(selectedProfileName))
             {


### PR DESCRIPTION
Editor was not clearing properly when reselecting profile, resulting in false positive SDK out of date errors.

Fixed by simply restarting editor when reselecting profile.