### PR TITLE
Added icons AST to acceptable legacy lag fix files

### DIFF
--- a/FrostyPlugin/Legacy/LegacyFileManagerV2.cs
+++ b/FrostyPlugin/Legacy/LegacyFileManagerV2.cs
@@ -221,7 +221,9 @@ namespace Frosty.Core.Legacy
 
             App.AssetManager.RevertAsset(lfe);
 
-            if (lfe.Filename == "portraits" || lfe.Filename == "portraits_256")
+            string[] lagFixableFiles = {"portraits", "portraits_256", "icons"};
+
+            if (lagFixableFiles.Contains<string>(lfe.Filename))
             {
                 Guid originalChunkId = lfe.ChunkId;
                 ChunkAssetEntry orig = App.AssetManager.GetChunkEntry(lfe.ChunkId);


### PR DESCRIPTION
The icons AST will now use the "legacy lag fix" edit method of editing the original chunk, in addition to the portrait ASTs.

Game seemed to be fine when testing re-importing original AST, but needs further testing.